### PR TITLE
add libzip-dev to dependencies to build php as it's no longer include…

### DIFF
--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -6,6 +6,7 @@ RUN buildDeps=" \
         default-libmysqlclient-dev \
         libbz2-dev \
         libsasl2-dev \
+	libzip-dev \
     " \
     runtimeDeps=" \
         curl \


### PR DESCRIPTION
…d in php package

fixes #1 